### PR TITLE
Fix examples in shape helper docstring

### DIFF
--- a/bbs_font/ascii_art.py
+++ b/bbs_font/ascii_art.py
@@ -18,8 +18,8 @@ def _make_shapes(count: int) -> tuple[str, str]:
 
     Examples
     --------
-    ``count=1`` yields ``("/\\", "\\///")``.
-    ``count=2`` yields ``("/\\\\", "\\//////")``.
+    ``count=1`` yields ``("/\\\\\\", "\\///")``.
+    ``count=2`` yields ``("/\\\\\\\\\\", "\\/////")``.
     """
 
     run = 2 * count + 1


### PR DESCRIPTION
## Summary
- fix the docstring examples for `_make_shapes`

## Testing
- `ruff format bbs_font/ascii_art.py`
- `ruff check`
- `ty check`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6883c7674bac83228eabd5a4b0256976

## Summary by Sourcery

Correct the example outputs in the `_make_shapes` function docstring to match the actual returned shapes.

Documentation:
- Update the `count=1` example to show ("/\\\\\\","\\///")
- Update the `count=2` example to show ("/\\\\\\\\","\\/////")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated docstring examples to accurately reflect output values for specific inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->